### PR TITLE
Fix issue in SQLite table definition reader

### DIFF
--- a/src/SQLite/SQLiteTableDefinitionReader.php
+++ b/src/SQLite/SQLiteTableDefinitionReader.php
@@ -261,7 +261,9 @@ class SQLiteTableDefinitionReader implements TableDefinitionReader {
 		$indexes = array();
 
 		foreach( $results as $result ) {
-			$indexes[] = $this->getIndex( $result->sql, $tableName );
+			if ( $result->sql !== null ) {
+				$indexes[] = $this->getIndex( $result->sql, $tableName );
+			}
 		}
 
 		return $indexes;


### PR DESCRIPTION
The array can contain "empty elements" where the sql key is null.
