### PR TITLE
Drop .coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: travis-ci
-src_dir: src
-coverage_clover: build/logs/clover.xml


### PR DESCRIPTION
I think this service is not used any more and this file is an unused, possibly outdated fragment now. I may be wrong. If you think I am, please show me the place where Coveralls is used and close this PR.
